### PR TITLE
fixes support for gzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ module.exports = function(environment) {
 }
 ```
 
+### Connection String
 You can also connect using your connection string, set it as `connectionString: "my-connection-string"`.
-It's possible to gzip assets, but it leads to strange results (https://github.com/duizendnegen/ember-cli-deploy-azure/issues/6).
+
+### Gzip Support
+If you're using [ember-cli-deploy-gzip](https://github.com/ember-cli-deploy/ember-cli-deploy-gzip) to automatically compress your assets using gzip, this plugin will automatically detect files that have been gzipped and set the proper `Content-Encoding` header within Azure Blob Storage.
+
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -17,9 +17,7 @@ module.exports = {
       name: options.name,
 
       defaultConfig: {
-        containerName: 'emberdeploy',
-        gzipExtensions: ['js', 'css', 'svg'],
-        gzip: false
+        containerName: 'emberdeploy'
       },
 
       _createClient: function() {
@@ -45,6 +43,7 @@ module.exports = {
       },
 
       upload: function(context) {
+
         var client = this._createClient();
         var _this = this;
 
@@ -76,7 +75,8 @@ module.exports = {
                   var walker = walk.walk(distDir, { followLinks: false });
 
                   walker.on("file",  function (root, fileStats, next) {
-                    _this._uploadFile(root, fileStats, next, context.distDir, client);
+                    var gzippedFiles = context.gzippedFiles || [];
+                    _this._uploadFile(root, fileStats, next, context.distDir, client, gzippedFiles);
                   });
 
                   walker.on("errors", function(root, nodeStatsArray, next) {
@@ -101,7 +101,7 @@ module.exports = {
           });
         });
       },
-      _uploadFile: function(root, fileStat, next, distDir, client) {
+      _uploadFile: function(root, fileStat, next, distDir, client, gzippedFiles) {
         var _this = this;
 
         var containerName = this.readConfig("containerName");
@@ -113,12 +113,7 @@ module.exports = {
 
         var options = {}
 
-        var extname = path.extname(resolvedFile).replace('.');
-        var gzipExtensions = this.readConfig("gzipExtensions");
-        var hasBeenGziped = gzipExtensions.indexOf(extname) !== -1;
-        var gzipEnabled = this.readConfig("gzip");
-
-        if(gzipEnabled && hasBeenGziped) {
+        if (gzippedFiles.indexOf(targetFile) != -1) {
           options["contentEncoding"] = "gzip";
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-azure-blob",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Deploy assets from Ember App to Azure Blob using ember-cli-deploy.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Hello! The original gzip code wasn't working properly due to `extname` being returned with `undefined` prefixed to the string. 

To simplify things and take advantage of the new build pipeline, I made an assumption that gzip support should automatically be enabled only if [ember-cli-deploy-gzip](https://github.com/ember-cli-deploy/ember-cli-deploy-gzip) is part of the pipeline. That said, I used the new deployment context to check to see what files were gzipped, if any, and then apply the proper `Content-Encoding` to Azure Blob Storage.

Let me know what you think.

Cheers.