### PR TITLE
Configurable cache control policy

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,14 @@ module.exports = {
       defaultConfig: {
         containerName: 'emberdeploy',
         cacheControl: {
-          extensions: []
+          extensions: [
+            { extension: 'png', policy: 'max-age=604800' },
+            { extension: 'jpg', policy: 'max-age=604800' },
+            { extension: 'gif', policy: 'max-age=604800' },
+            { extension: 'jpeg', policy: 'max-age=604800' },
+            { extension: 'css', policy: 'max-age=86400' },
+            { extension: 'js', policy: 'max-age=86400' }
+          ]
         }
       },
 


### PR DESCRIPTION
Cache control header added to every assets pushed to an azure blob storage container. By default every assets will be given the `no-cache, must-revalidate` value for the content control header.

For the more common assets types: images, styling and javascript a sensible caching policy has been specified

Configuration is done as described in issue #3. However support for specifying a cache control policy for specific file paths has not been added.